### PR TITLE
feat: add self-contained MyAssistant dashboard

### DIFF
--- a/MyAssistant.html
+++ b/MyAssistant.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MyAssistant Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root,
+    [data-theme="light"] {
+      --bg-color: #f3f4f6;
+      --card-bg-color: #ffffff;
+      --text-color: #1f2937;
+      --text-color-secondary: #6b7280;
+      --border-color: #e5e7eb;
+      --primary-blue: #2563eb;
+      --icon-bg-color: #e0e7ff;
+    }
+    [data-theme="dark"] {
+      --bg-color: #111827;
+      --card-bg-color: #1f2937;
+      --text-color: #f9fafb;
+      --text-color-secondary: #9ca3af;
+      --border-color: #374151;
+      --primary-blue: #3b82f6;
+      --icon-bg-color: #374151;
+    }
+    body {
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      font-family: 'Inter', sans-serif;
+    }
+    .card {
+      background-color: var(--card-bg-color);
+      border: 1px solid var(--border-color);
+      border-radius: 0.5rem;
+      box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+    }
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: #888 var(--bg-color);
+    }
+    [data-theme="dark"] * {
+      scrollbar-color: #555 var(--bg-color);
+    }
+    ::-webkit-scrollbar {
+      width: 8px;
+    }
+    ::-webkit-scrollbar-track {
+      background: var(--bg-color);
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: #888;
+    }
+    [data-theme="dark"] ::-webkit-scrollbar-thumb {
+      background-color: #555;
+    }
+    #toast {
+      transition: opacity 0.3s;
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+  <header class="fixed top-0 left-0 right-0 bg-[#2563eb] text-white p-4 shadow z-50">
+    <h1 class="text-xl font-semibold">MyAssistant</h1>
+  </header>
+  <main class="pt-20 p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+    <section class="card p-4">
+      <h2 class="font-semibold mb-2">Clipboard</h2>
+      <p class="text-[var(--text-color-secondary)] mb-4">Click the code below to copy.</p>
+      <pre class="copyable bg-[var(--icon-bg-color)] p-2 rounded cursor-pointer overflow-x-auto"><code>npm install myassistant</code></pre>
+    </section>
+    <section class="card p-4">
+      <h2 class="font-semibold mb-2">Data Table</h2>
+      <div class="overflow-y-auto max-h-48">
+        <table class="min-w-full text-sm">
+          <thead class="bg-[var(--icon-bg-color)] sticky top-0">
+            <tr>
+              <th class="text-left p-2">Name</th>
+              <th class="text-left p-2">Role</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-t border-[var(--border-color)]">
+              <td class="p-2">Alice</td>
+              <td class="p-2">Engineer</td>
+            </tr>
+            <tr class="border-t border-[var(--border-color)]">
+              <td class="p-2">Bob</td>
+              <td class="p-2">Designer</td>
+            </tr>
+            <tr class="border-t border-[var(--border-color)]">
+              <td class="p-2">Charlie</td>
+              <td class="p-2">Manager</td>
+            </tr>
+            <tr class="border-t border-[var(--border-color)]">
+              <td class="p-2">Dana</td>
+              <td class="p-2">Support</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+  <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 bg-[var(--card-bg-color)] text-[var(--text-color)] border border-[var(--border-color)] rounded px-4 py-2 shadow-sm opacity-0 pointer-events-none"></div>
+  <button id="theme-toggle" class="fixed bottom-4 left-4 p-2 bg-[var(--card-bg-color)] border border-[var(--border-color)] rounded-full shadow-sm">
+    <svg id="sun-icon" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <circle cx="12" cy="12" r="5" />
+      <path d="M12 1v2m0 18v2m9-9h2M1 12H3m15.364-7.364l1.414 1.414M4.222 19.778l1.414-1.414m0-12.728L4.222 4.222m16.556 16.556l-1.414-1.414" />
+    </svg>
+    <svg id="moon-icon" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+  </button>
+  <script>
+    (function() {
+      const htmlEl = document.documentElement;
+      const toggleBtn = document.getElementById('theme-toggle');
+      const sunIcon = document.getElementById('sun-icon');
+      const moonIcon = document.getElementById('moon-icon');
+      const toast = document.getElementById('toast');
+
+      function setTheme(theme) {
+        htmlEl.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        if (theme === 'dark') {
+          sunIcon.classList.add('hidden');
+          moonIcon.classList.remove('hidden');
+        } else {
+          sunIcon.classList.remove('hidden');
+          moonIcon.classList.add('hidden');
+        }
+      }
+
+      const savedTheme = localStorage.getItem('theme') || 'light';
+      setTheme(savedTheme);
+
+      toggleBtn.addEventListener('click', () => {
+        const current = htmlEl.getAttribute('data-theme');
+        const next = current === 'light' ? 'dark' : 'light';
+        setTheme(next);
+      });
+
+      document.querySelectorAll('.copyable').forEach(el => {
+        el.addEventListener('click', () => {
+          navigator.clipboard.writeText(el.innerText.trim()).then(() => {
+            toast.textContent = 'Copied to clipboard!';
+            toast.classList.remove('opacity-0');
+            setTimeout(() => {
+              toast.classList.add('opacity-0');
+            }, 2000);
+          });
+        });
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build MyAssistant dashboard with Tailwind styling and responsive cards
- add theme toggle, clipboard copy with toast, and custom scrollbars

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cadb4450832a8e8865268a1e5185