### PR TITLE
Hide remote detail text until widget expands

### DIFF
--- a/MyAssistantUpdatedNotes.html
+++ b/MyAssistantUpdatedNotes.html
@@ -208,6 +208,11 @@
       min-height: 500px;
     }
 
+    /* Hide all remote detail panels by default to prevent flash before JS hides them */
+    #remoteDetail > div {
+      display: none;
+    }
+
     .remoteMain {
       /*float: left;*/
       float: right;


### PR DESCRIPTION
## Summary
- hide remote detail panels by default to avoid text flashing before widget collapse completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bfe2367c832a83d98bbda3965e6a